### PR TITLE
Add use to the closure in cms_model

### DIFF
--- a/application/models/cms_model.php
+++ b/application/models/cms_model.php
@@ -1075,7 +1075,7 @@ class CMS_Model extends CI_Model {
 			};
 	    } else {
 	    	$_this = clone $this;
-	        $replacement = function($arr){
+	        $replacement = function($arr) use ($_this) {
 				return $_this->cms_lang($arr[1]);
 			};
 	    }


### PR DESCRIPTION
Added a use ($_this) to the cms_model.php to make the $_this variable available within the anonymous function / closure.

Also looks like my IDE trimmed all the whitespace  :)
