### PR TITLE
Nordrassil - adding column without defined lookup table failed

### DIFF
--- a/modules/nordrassil/assets/db/install.sql
+++ b/modules/nordrassil/assets/db/install.sql
@@ -58,7 +58,7 @@ CREATE TABLE `{{ complete_table_name:column }}` (
   `data_type` varchar(50) NOT NULL,
   `data_size` int(11) NULL,
   `role` varchar(50) NOT NULL,
-  `lookup_table_id` int(11) NOT NULL,
+  `lookup_table_id` int(11) NULL,
   `lookup_column_id` int(11) NULL,
   `relation_table_id` int(11) NULL,
   `relation_table_column_id` int(11) NULL,


### PR DESCRIPTION
When in nordrassil trying to save new column to table, no error is shown with silent 500. Problem is not given lookup_table_id on INSERT query, this will make it optional.
