### PR TITLE
If page isn't found, show 404.

### DIFF
--- a/modules/main/controllers/Main.php
+++ b/modules/main/controllers/Main.php
@@ -177,9 +177,13 @@ class Main extends CMS_Controller
     }
 
     //this is used for the real static page which doesn't has any URL in navigation management
-    public function static_page($navigation_name)
+    public function static_page($navigation_name=NULL)
     {
-        $this->view('CMS_View', null, $navigation_name);
+        if($navigation_name !== NULL){
+            $this->view('CMS_View', null, $navigation_name);
+        }else{
+           $this->view('not_found_index', NULL, 'main_404');
+        }
     }
 
     public function login()


### PR DESCRIPTION
CodeIgniter threw errors if no $navigation_name parameter was passed to this function. I've set it a default value and added a check to see if the 404_page should show by default.