### PR TITLE
Set a 404 http header

### DIFF
--- a/application/controllers/Not_found.php
+++ b/application/controllers/Not_found.php
@@ -2,6 +2,7 @@
 
 class Not_found extends CMS_Controller{
 	public function index(){
+		$this->output->set_status_header('404');
 		$this->view('not_found_index', NULL, 'main_404');
 	}
 }


### PR DESCRIPTION
If a page isn't found, a 404 error should be output to the browser.